### PR TITLE
Fix V3013

### DIFF
--- a/Port/WinSerialStream.cs
+++ b/Port/WinSerialStream.cs
@@ -394,7 +394,7 @@ namespace SerialPortLib2.Port
 
         public void DiscardOutBuffer()
         {
-            if (!PurgeComm(handle, PurgeRxClear))
+            if (!PurgeComm(handle, PurgeTxClear))
                 ReportIOError(null);
         }
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

-  It is odd that the body of 'DiscardInBuffer' function is fully equivalent to the body of 'DiscardOutBuffer' function (389, line 395). SerialPortLib WinSerialStream.cs 389